### PR TITLE
Restart a pce node

### DIFF
--- a/modules/ROOT/pages/operating-about.adoc
+++ b/modules/ROOT/pages/operating-about.adoc
@@ -12,3 +12,4 @@ The following topics describe how to manage Anypoint Private Cloud after install
 *** xref:config-add-proxy-whitelist.adoc[To Add Whitelist Addresses for API Platform Proxies]
 *** xref:demo-ldap-server.adoc[To Configure the Demo LDAP Server]
 *** xref:ext-analytics-elk.adoc[To Analyze Business and API Data using ELK]
+*** xref:restarting-a-node.adoc[Stop, Restart, or Update an Anypoint Platform Private Cloud Edition Node]

--- a/modules/ROOT/pages/restarting-a-node.adoc
+++ b/modules/ROOT/pages/restarting-a-node.adoc
@@ -1,0 +1,78 @@
+= Stop, Restart, or Update an Anypoint Private Cloud Edition Node
+ifndef::env-site,env-github[]
+include::_attributes.adoc[]
+endif::[]
+
+This topic describes the processes for removing an Anypoint Platform PCE node from active service, and returning it to service when ready.
+
+== Notes
+
+[NOTE]
+To preserve your data in case of system failure, ensure that your system is backed up before attempting node maintenance.
+[NOTE]
+The steps below must be performed on a single Anypoint Platform PCE node at a time.  If maintenance is required on more than one node, the entire process must be completed on a single node before the next node is addressed.
+
+== Drain the Node
+
+Before any maintenance or restart of a node can be performed, it must be removed from the cluster and its workload reassigned to the other nodes in the cluster.
+
+. Check if the firewalld service is running and enabled:
++
+----
+service firewalld status
+----
+. If firewalld is running, stop, disable, and mask it:
++
+----
+sudo systemctl stop firewalld
+sudo systemctl disable firewalld
+sudo systemctl mask firewalld
+----
+. Retrieve the *name* of target node:
++
+----
+kubectl get nodes
+----
+. Drain the node:
++
+----
+kubectl drain --delete-local-data --ignore-daemonsets <node_name>
+----
+. Stop Gravity
++
+----
+systemctl list-units | grep "planet-master"
+  # note the full name of the Gravity "planet-master" unit
+systemctl stop <garvity_unit_name>
+----
+
+== Apply Node Maintenance
+
+Once the node has been drained and cordoned, any desired maintenance or a system reboot may be performed.  Caution must be used, however, to avoid any updates to the system that violate the requirements of Anypoint Platform PCE.
+
+== Rejoin the Node
+
+. Check Gravity Planet Master and Teleport status:
++
+----
+systemctl list-units | grep gravity__gravitational
+----
+. If either Gravity service is not “loaded active running”, then enable it:
++
+----
+systemctl enable <name_of_the_gravity_unit>
+----
+. Uncordon the node:
++
+----
+kubectl uncordon <node_name>
+----
+. Verify cluster status:
++
+----
+gravity status
+----
++
+****
+This command should show all nodes of the cluster with "healthy" status.  Only after verifying that the node has rejoined the cluster and is in healthy status can the process be repeated for other nodes in the cluster.
+****


### PR DESCRIPTION
Add new page to the Managing Anypoint Private Cloud section for stop/start/restart a PCE node.  Relocating this content from the PCE Operations Manual.