### PR TITLE
Update upgrade.adoc

### DIFF
--- a/modules/ROOT/pages/upgrade.adoc
+++ b/modules/ROOT/pages/upgrade.adoc
@@ -32,6 +32,31 @@ Before migrating, ensure that you have performed and met the following prerequis
 
 * Ensure that your environment meets all of the system and network requirements described in xref:prereq-workflow.adoc[Workflow: Install and Verify Prerequisites for Physical Servers]
 
+* Ensure that the following kernel modules are enabled: https://docs.mulesoft.com/private-cloud/2.0/prereq-software#kernel-modules
+
+** `br_netfilter`
+** `ebtable_filter`
+** `ip_tables`
+** `iptable_filter`
+** `iptable_nat`
+
+.. Verify that each module is loaded using the following as an example:
++
+----
+root$ lsmod | grep br_netfilter
+----
+.. Repeat this command for each of the kernel modules above. If this command does not display any output, then the module is not loaded. In this case, load the module using `modprobe`:
++
+----
+root$ modprobe br_netfilter
+----
+.. To ensure the module is loaded after a reboot:
++
+----
+root$ echo 'br_netfilter' > /etc/modules-load.d/br_netfilter.conf
+----
+.. Replace `br_netfilter` with the name of the kernel module you are checking.
+
 * Enable TCP ports `53`, `3011`, `3012` intra-node to allow communication with the database cluster.
 
 * Ensure you have permission to run the `sudo` command on the node where you launch the migration tool.

--- a/modules/ROOT/pages/upgrade.adoc
+++ b/modules/ROOT/pages/upgrade.adoc
@@ -32,30 +32,7 @@ Before migrating, ensure that you have performed and met the following prerequis
 
 * Ensure that your environment meets all of the system and network requirements described in xref:prereq-workflow.adoc[Workflow: Install and Verify Prerequisites for Physical Servers]
 
-* Ensure that the following kernel modules are enabled: https://docs.mulesoft.com/private-cloud/2.0/prereq-software#kernel-modules
-
-** `br_netfilter`
-** `ebtable_filter`
-** `ip_tables`
-** `iptable_filter`
-** `iptable_nat`
-
-.. Verify that each module is loaded using the following as an example:
-+
-----
-root$ lsmod | grep br_netfilter
-----
-.. Repeat this command for each of the kernel modules above. If this command does not display any output, then the module is not loaded. In this case, load the module using `modprobe`:
-+
-----
-root$ modprobe br_netfilter
-----
-.. To ensure the module is loaded after a reboot:
-+
-----
-root$ echo 'br_netfilter' > /etc/modules-load.d/br_netfilter.conf
-----
-.. Replace `br_netfilter` with the name of the kernel module you are checking.
+* Ensure that the necessary kernel modules are enabled as described in xref:private-cloud::prereq-software#kernel-modules[Software Requirements for Anypoint Private Cloud, role=external, window=_blank]. 
 
 * Enable TCP ports `53`, `3011`, `3012` intra-node to allow communication with the database cluster.
 

--- a/modules/ROOT/pages/upgrade.adoc
+++ b/modules/ROOT/pages/upgrade.adoc
@@ -30,9 +30,9 @@ Before migrating, ensure that you have performed and met the following prerequis
 
 * Anypoint Private Cloud, version 2.0 requires that you have an NFS server installed and configured. Ensure that this is installed before beginning the upgrade. See xref:prereq-hardware.adoc[Private Cloud Edition Hardware Requirements]
 
-* Ensure that your environment meets all of the system and network requirements described in xref:prereq-workflow.adoc[Workflow: Install and Verify Prerequisites for Physical Servers]
+* Ensure that your environment meets all of the system and network requirements described in xref:prereq-workflow.adoc[Workflow: Install and Verify Prerequisites for Physical Servers].
 
-* Ensure that the necessary kernel modules are enabled as described in xref:private-cloud::prereq-software#kernel-modules[Software Requirements for Anypoint Private Cloud, role=external, window=_blank]. 
+* Ensure that the necessary kernel modules are enabled as described in xref:prereq-software.adoc#kernel-modules[Software Requirements for Anypoint Private Cloud]. 
 
 * Enable TCP ports `53`, `3011`, `3012` intra-node to allow communication with the database cluster.
 


### PR DESCRIPTION
In https://www.mulesoft.org/jira/browse/DOCS-4928, it indicates that the modules to load should match https://github.com/mulesoft/private-cloud-provisioner/blob/845984f56414dfb5e095ae969c02f3aae6235d4d/scripts/terraform/modules/nodes/user-data.tpl#L47-L69. However, the existing instructions contain `ip_tables` but not `overlay`. 