### PR TITLE
Update prereq-aws-terraform.adoc

### DIFF
--- a/modules/ROOT/pages/dummy-relnotes.adoc
+++ b/modules/ROOT/pages/dummy-relnotes.adoc
@@ -105,7 +105,7 @@ Contact MuleSoft professional services prior to upgrading. MuleSoft professional
 | Mule runtime engine | 3.7.x , 3.8.x, 3.9.x, 4.0.x, 4.1.x, 4.2.x, 4.3.0
 | API Gateway Runtime | 2.1.x - 2.2.x
 | Anypoint Runtime Manager Agent | 1.7 - 1.9.x, 2.1.x
-| Anypoint Studio | 6, 7.4
+| Anypoint Studio | 6, 7.4, 7.7
 | Infrastructure providers |
 * VMWare
 * Bare metal
@@ -115,7 +115,6 @@ Contact MuleSoft professional services prior to upgrading. MuleSoft professional
 == Upgrade Paths
 Upgrades from the following PCE versions are supported:
 
-* PCE 2.0.x
 * PCE 2.1.x
 
 == Fixed Issues

--- a/modules/ROOT/pages/prereq-aws-terraform.adoc
+++ b/modules/ROOT/pages/prereq-aws-terraform.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-If you are using Amazon Web Services (AWS), you must create the resources required to install Anypoint Platform Private Cloud Edition (Anypoint Platform PCE)on AWS. Anypoint Platform PCE supports 3-node and 6-node configurations in a production environment on AWS.
+If you are using Amazon Web Services (AWS), you must create the resources required to install Anypoint Platform Private Cloud Edition (Anypoint Platform PCE) on AWS. Anypoint Platform PCE supports 4-node and 7-node configurations in a production environment on AWS.
 
 You do not need this information if you are starting from bare metal servers.
 
@@ -20,11 +20,11 @@ To install Anypoint Platform PCE on AWS:
 [%header%autowidth.spread]
 .AWS-Created Resources
 |===
-| AWS Resource | Number Required (3-node) | Number Required (6-node)
-| m5.2xlarge | 3 | 6
-| root disk @ 500 iops | 3 | 6
-| EBS volumes @ 1500 iops | 6 | 12
-| EBS volume @ 3000 iops | 6 | 12
+| AWS Resource | Number Required (4-node) | Number Required (7-node)
+| m5.2xlarge | 4 | 7
+| root disk @ 500 iops | 4 | 7
+| EBS volumes @ 1500 iops | 8 | 14
+| EBS volume @ 3000 iops | 8 | 14
 | Amazon ELB | 1 | 1
 | t2.medium | 1 | 1
 |===
@@ -45,13 +45,13 @@ https://anypoint-anywhere.s3.amazonaws.com/pcp/private-cloud-provisioner-3.0.6.t
 . Copy the provisioner Docker image to the instance via SCP:
 +
 ----
-scp -i <guest>.pem ~/Downloads/private-cloud-provisioner-2.1.11.tar.gz ec2-user@18.221.155.87:/home/ec2-user
+scp -i <guest>.pem ~/Downloads/private-cloud-provisioner-3.0.6.tar.gz ec2-user@W.X.Y.Z:/home/ec2-user
 ----
 
 . SSH into the instance:
 +
 ----
-ssh -i 'anypoint.pem' ec2-user@18.221.155.87
+ssh -i 'anypoint.pem' ec2-user@W.X.Y.Z
 ----
 
 . Create the variable file (pce.env) with the environment details using the following values:
@@ -68,7 +68,7 @@ ssh -i 'anypoint.pem' ec2-user@18.221.155.87
 | TF_VAR_ssh_user=<SSH_USER> | Specifies the ssh user, for example, `ec2-user`, `centos`, etc.
 | TELEKUBE_CLUSTER_NAME | Specifies the name of the cluster and the corresponding AWS resources.
 | TELEKUBE_NODE_PROFILES | Must be set to `node`.
-| TELEKUBE_NODE_PROFILE_COUNT_node | Specifies the number of nodes in your cluster. Possible values are `3` and `6`.
+| TELEKUBE_NODE_PROFILE_COUNT_node | Specifies the number of nodes in your cluster. Possible values are `4` and `7`.
 | TELEKUBE_NODE_PROFILE_INSTANCE_TYPE_node | Must be `m5.2xlarge`.
 | TELEKUBE_NODE_PROFILE_COUNT_node_amv | Specifies the number of nodes for the AMV addon in your cluster. Must be `3` if planning to install the AMV addon. Omit otherwise.
 | TELEKUBE_NODE_PROFILE_INSTANCE_TYPE_node_amv | Must be `m5.4xlarge` if planning to install the AMV addon. Omit otherwise.
@@ -96,20 +96,20 @@ You can also include the following set of optional environment variables:
 . Load the provisioner Docker image into the local Docker registry:
 +
 ----
-docker load -i private-cloud-provisioner-2.1.11.tar.gz
+docker load -i private-cloud-provisioner-3.0.6.tar.gz
 ----
 
 . Perform a dry-run test:
 +
 ----
-docker run --rm --env-file pce.env artifacts.msap.io/mulesoft/core-paas-private-cloud-provisioner:v2.1.11 dry-run
+docker run --rm --env-file pce.env artifacts.msap.io/mulesoft/core-paas-private-cloud-provisioner:v3.0.6 dry-run
 ----
 +
 
 .  Run the provisioner:
 +
 ----
-docker run --rm --env-file pce.env artifacts.msap.io/mulesoft/core-paas-private-cloud-provisioner:v2.1.11 cluster-provision
+docker run --rm --env-file pce.env artifacts.msap.io/mulesoft/core-paas-private-cloud-provisioner:v3.0.6 cluster-provision
 ----
 +
 After the provisioner runs successfully, it displays information about your environment including IP addresses and DNS name of the load balancer.
@@ -121,7 +121,7 @@ After the provisioner runs successfully, it displays information about your envi
 You can have your own shell scripts to run on the provisioned instances before and/or after the PCE provisioner scripts. To do so, place your shell scripts with .sh extension inside a folder named `pre-user-data` and/or `post-user-data`. Include the following volume mounts on the docker run command:
 
 ----
-docker run --rm -v $(pwd)/pre-user-data:/usr/local/bin/provisioner/terraform/external/pre-user-data -v $(pwd)/post-user-data:/usr/local/bin/provisioner/terraform/external/post-user-data --env-file pce.env artifacts.msap.io/mulesoft/core-paas-private-cloud-provisioner:v2.1.11 cluster-provision
+docker run --rm -v $(pwd)/pre-user-data:/usr/local/bin/provisioner/terraform/external/pre-user-data -v $(pwd)/post-user-data:/usr/local/bin/provisioner/terraform/external/post-user-data --env-file pce.env artifacts.msap.io/mulesoft/core-paas-private-cloud-provisioner:v3.0.6 cluster-provision
 ----
 
 == Open Port 61009 Before Installation
@@ -133,7 +133,7 @@ If you are installing Anypoint Private Cloud using the GUI-based installer, you 
 You can destroy all resources that were created using the provisioner by running the `cluster-deprovision` command, as shown in the following example. Ensure the `TELEKUBE_CLUSTER_NAME` environment variable in your environment file has the correct value for the target cluster you want to destroy:
 
 ----
-docker run --rm --env-file pce.env artifacts.msap.io/mulesoft/core-paas-private-cloud-provisioner:v2.1.11 cluster-deprovision
+docker run --rm --env-file pce.env artifacts.msap.io/mulesoft/core-paas-private-cloud-provisioner:v3.0.6 cluster-deprovision
 ----
 
 == Troubleshooting

--- a/modules/ROOT/pages/prereq-aws-terraform.adoc
+++ b/modules/ROOT/pages/prereq-aws-terraform.adoc
@@ -81,7 +81,7 @@ You can also include the following set of optional environment variables:
 .Optional Environment Variables
 |===
 | Name | Description
-| TF_VAR_ami_name | Specifies the AMI name to be used for the instances. Use the AMI name, *NOT* the AMI ID. *Ensure that the AMI does not provision any additional volumes*. If you do not set this variable, the provisioner uses the following AMI by default: `RHEL-7.6_HVM_GA-20181017-x86_64-0-Hourly2-GP2`
+| TF_VAR_ami_name | (TBD Update: Please use `RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2`) Specifies the AMI name to be used for the instances. Use the AMI name, *NOT* the AMI ID. *Ensure that the AMI does not provision any additional volumes*. If you do not set this variable, the provisioner uses the following AMI by default: `RHEL-7.6_HVM_GA-20181017-x86_64-0-Hourly2-GP2`
 | TF_VAR_monitoring=<true or false> | If true, creates basic instance alarms in Cloudwatch.
 | TF_VAR_use_bastion=<true or false> | If true, creates a small instance (using an ASG) in a public subnet as a jumpbox and associates a public IP address, and launches the cluster instances in the private subnets.
 | TF_VAR_internal=<true or false> | If true, the cluster instances are launched in private subnets and do not have public IPs associated with them. Also, the provisioned load balancer is internal only.

--- a/modules/ROOT/pages/prereq-aws-terraform.adoc
+++ b/modules/ROOT/pages/prereq-aws-terraform.adoc
@@ -81,7 +81,7 @@ You can also include the following set of optional environment variables:
 .Optional Environment Variables
 |===
 | Name | Description
-| TF_VAR_ami_name | (TBD Update: Please use `RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2`) Specifies the AMI name to be used for the instances. Use the AMI name, *NOT* the AMI ID. *Ensure that the AMI does not provision any additional volumes*. If you do not set this variable, the provisioner uses the following AMI by default: `RHEL-7.6_HVM_GA-20181017-x86_64-0-Hourly2-GP2`
+| TF_VAR_ami_name | (TO-DO: This may change before the PCE 3.0 release, but for now please use `RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2`.) Specifies the AMI name to be used for the instances. Use the AMI name, *NOT* the AMI ID. *Ensure that the AMI does not provision any additional volumes*. If you do not set this variable, the provisioner uses the following AMI by default: `RHEL-7.6_HVM_GA-20181017-x86_64-0-Hourly2-GP2`
 | TF_VAR_monitoring=<true or false> | If true, creates basic instance alarms in Cloudwatch.
 | TF_VAR_use_bastion=<true or false> | If true, creates a small instance (using an ASG) in a public subnet as a jumpbox and associates a public IP address, and launches the cluster instances in the private subnets.
 | TF_VAR_internal=<true or false> | If true, the cluster instances are launched in private subnets and do not have public IPs associated with them. Also, the provisioned load balancer is internal only.

--- a/modules/ROOT/pages/prereq-aws-terraform.adoc
+++ b/modules/ROOT/pages/prereq-aws-terraform.adoc
@@ -41,7 +41,7 @@ You can also run provisioner remotely from any other machine with Docker and int
 
 . Download the Private Cloud Provisioner (PCP) Docker image from:
 +
-https://anypoint-anywhere.s3.amazonaws.com/pcp/private-cloud-provisioner-2.1.11.tar.gz?Signature=%2BoEHrGHnaF%2BRT%2FVHpnh2UnMMbj0%3D&AWSAccessKeyId=AKIAI6LBJNQFR2V3CQWQ&Expires=1756608559
+https://anypoint-anywhere.s3.amazonaws.com/pcp/private-cloud-provisioner-3.0.6.tar.gz?AWSAccessKeyId=AKIAI6LBJNQFR2V3CQWQ&Signature=%2BGGknEu%2FGfxCDNPpKMbpEJdOqjY%3D&Expires=1759202748
 . Copy the provisioner Docker image to the instance via SCP:
 +
 ----
@@ -67,9 +67,11 @@ ssh -i 'anypoint.pem' ec2-user@18.221.155.87
 | AWS_REGION | Specifies the AWS region where Terraform creates the cluster, for example, `us-east-2`.
 | TF_VAR_ssh_user=<SSH_USER> | Specifies the ssh user, for example, `ec2-user`, `centos`, etc.
 | TELEKUBE_CLUSTER_NAME | Specifies the name of the cluster and the corresponding AWS resources.
+| TELEKUBE_NODE_PROFILES | Must be set to `node`.
 | TELEKUBE_NODE_PROFILE_COUNT_node | Specifies the number of nodes in your cluster. Possible values are `3` and `6`.
 | TELEKUBE_NODE_PROFILE_INSTANCE_TYPE_node | Must be `m5.2xlarge`.
-| TELEKUBE_NODE_PROFILES | Must be set to `node`.
+| TELEKUBE_NODE_PROFILE_COUNT_node_amv | Specifies the number of nodes for the AMV addon in your cluster. Must be `3` if planning to install the AMV addon. Omit otherwise.
+| TELEKUBE_NODE_PROFILE_INSTANCE_TYPE_node_amv | Must be `m5.4xlarge` if planning to install the AMV addon. Omit otherwise.
 | TF_VAR_high_performance_disks | Must be set to `true` for production environments.
 |===
 +

--- a/modules/ROOT/pages/prereq-hardware.adoc
+++ b/modules/ROOT/pages/prereq-hardware.adoc
@@ -28,7 +28,7 @@ For production environments, each node in your configuration must have the follo
 .Dedicated Device Requirements
 |===
 | Component |Size|Minimum IOPS|Mount Point|Description
-|HDD 2 xref:prereq-hardware#system-state-directory-device[System State Directory Device] | 100 GB |1500|/var/lib/gravity | Stores system configuration and metadata, including databases and packages. Because package sizes can be large, it is important to estimate the minimum size requirements and allocate enough space as a dedicated device before installation.
+|HDD 2 xref:prereq-hardware#system-state-directory-device[System State Directory Device] | 200 GB |1500|/var/lib/gravity | Stores system configuration and metadata, including databases and packages. Because package sizes can be large, it is important to estimate the minimum size requirements and allocate enough space as a dedicated device before installation.
 |HDD 3 xref:prereq-hardware#application-data-device[Application Data Device]| 250 GB |1500|/var/lib/data | Stores application configuration and data. The amount of space required should be at least 250 GB, but can vary depending on your specific use case. It is important to estimate the minimum size requirements and allocate enough space as a dedicated device ahead of time.
 |HDD 4 xref:prereq-hardware#docker-device[Docker Device] | 100 GB |3000|/var/lib/gravity/planet/docker | Used by Docker’s overlay storage driver. A minimum of 100GB is required for the overlay directory. Devices with 50GB or less will experience degraded system performance or might not work at all.
 |HDD 5 xref:prereq-hardware#etcd-device[Etcd Device] | 20 GB |3000|/var/lib/gravity/planet/etcd | Provides dedicated storage for the distributed database used for cluster coordination.
@@ -133,7 +133,7 @@ xvda    202:0    0   90G   0 disk
 xvdb    202:16   0  100G   0 disk /var/lib/gravity/planet/docker
 xvdc    202:32   0   20G   0 disk /var/lib/gravity/planet/etcd
 xvdd    202:48   0  250G   0 disk /var/lib/data
-xvde    202:64   0  100G   0 disk /var/lib/gravity
+xvde    202:64   0  200G   0 disk /var/lib/gravity
 xvdf    202:64   0   20G   0 disk /tmp
 ----
 
@@ -177,6 +177,7 @@ Your load balancer must route the following TCP ports:
 |`443` | `30443` | HTTPS port
 |`8083` | `30883` | HTTPS port for Mule runtimes to authenticate and renew certificates
 |`8889` | `30889` | WebSocket port for Mule runtimes to connect
+|`8895` | `30895` | (Only when Monitoring Center is enabled)
 |`9500` | `32009` | Ops Center access port
 |===
 
@@ -225,6 +226,11 @@ server {
 }
 
 server {
+   listen 8895;
+   proxy_pass 0.0.0.0:30895;
+}
+
+server {
    listen 9500;
    proxy_pass 0.0.0.0:32009;
 }
@@ -240,6 +246,7 @@ server {
 ----
 semanage port -a -t http_port_t  -p tcp 8083
 semanage port -a -t http_port_t  -p tcp 8889
+semanage port -a -t http_port_t  -p tcp 8895
 semanage port -a -t http_port_t  -p tcp 9500
 semanage port -a -t http_port_t  -p tcp 9501
 ----

--- a/modules/ROOT/pages/prereq-hardware.adoc
+++ b/modules/ROOT/pages/prereq-hardware.adoc
@@ -9,7 +9,13 @@ To ensure the performance and stability of Anypoint Platform Private Cloud Editi
 [IMPORTANT]
 Before you install Anypoint Platform PCE, your infrastructure team must review each of the following sections and verify that your environment meets the stated disk and device requirements. If needed, contact your MuleSoft representative for assistance.
 
-== Memory and CPU Requirements
+(TBD: Reword properly, or update the whole content to better include Mon Center)
+There are 2 components of PCE:
+- Anypoint Platform Core
+- Monitoring Center Add-On
+
+== Anypoint Platform Core
+=== Memory and CPU Requirements
 
 [%header%autowidth.spread]
 .Memory and CPU Requirements
@@ -39,7 +45,7 @@ For production environments, each node in your configuration must have the follo
 [NOTE]
 The space requirements listed in the previous table are based on average use. For environments with heavy traffic, validate the amount of space needed with your Customer Success Manager.
 
-== System State Directory Device
+=== System State Directory Device
 
 The main purpose of the system state directory device is to store system configuration and metadata, for example, database and packages. As package sizes can be arbitrarily large, it is important to estimate the minimum size requirements and allocate enough space for the dedicated device.
 
@@ -56,7 +62,7 @@ sudo systemctl enable var-lib-gravity.mount
 sudo systemctl start var-lib-gravity.mount
 ----
 
-== Application Data Device
+=== Application Data Device
 
 The main purpose of the application data directory device is to store application configuration and data. The minimum amount of space required is 250GB, but your use case might require more. It is important to allocate enough space for the dedicated device.
 
@@ -73,7 +79,7 @@ sudo systemctl enable var-lib-data.mount
 sudo systemctl start var-lib-data.mount
 ----
 
-== Etcd Device
+=== Etcd Device
 
 The main purpose of the etcd device is to provide dedicated storage for a distributed database used for cluster coordination. It does not require much space, 20GB is adequate.
 
@@ -97,7 +103,7 @@ sudo systemctl enable var-lib-gravity-planet-etcd.mount
 sudo systemctl start var-lib-gravity-planet-etcd.mount
 ----
 
-== Docker Device
+=== Docker Device
 
 Unless specified, Docker configuration defaults to the use of the overlay driver, which is recommended for production.
 
@@ -119,6 +125,129 @@ sudo systemctl daemon-reload
 sudo systemctl enable var-lib-gravity-planet-docker.mount
 sudo systemctl start var-lib-gravity-planet-docker.mount
 ----
+
+
+== Monitoring Center Add-On
+=== Memory and CPU Requirements
+
+(
+TDB: At the moment, the only difference between the Monitoring Center and the Platform Core nodes are Memory and CPU.
+The disks most probably need to be different but needs to be confirmed.
+)
+
+[%header%autowidth.spread]
+.Memory and CPU Requirements
+|===
+| Component |Requirement
+|RAM |64 GB
+|CPU |16 Cores
+|===
+
+[IMPORTANT]
+If the stated requirements for Memory and CPU are not met, Anypoint Platform PCE installation will fail. 
+
+For production environments, each node in your configuration must have the following dedicated devices. All devices must be formatted either as *xfs* or *ext4*.
+
+[%header%autowidth.spread]
+.Dedicated Device Requirements
+|===
+| Component |Size|Minimum IOPS|Mount Point|Description
+|HDD 2 xref:prereq-hardware#system-state-directory-device[System State Directory Device] | 200 GB |1500|/var/lib/gravity | Stores system configuration and metadata, including databases and packages. Because package sizes can be large, it is important to estimate the minimum size requirements and allocate enough space as a dedicated device before installation.
+|HDD 3 xref:prereq-hardware#application-data-device[Application Data Device]| 250 GB |1500|/var/lib/data | Stores application configuration and data. The amount of space required should be at least 250 GB, but can vary depending on your specific use case. It is important to estimate the minimum size requirements and allocate enough space as a dedicated device ahead of time.
+|HDD 4 xref:prereq-hardware#docker-device[Docker Device] | 100 GB |3000|/var/lib/gravity/planet/docker | Used by Docker’s overlay storage driver. A minimum of 100GB is required for the overlay directory. Devices with 50GB or less will experience degraded system performance or might not work at all.
+|HDD 5 xref:prereq-hardware#etcd-device[Etcd Device] | 20 GB |3000|/var/lib/gravity/planet/etcd | Provides dedicated storage for the distributed database used for cluster coordination.
+|/tmp (Installer) | 20 GB |N/A| |
+|/ (root) | 10 GB | N/A | | You must have at least 10GB in your home directory to download and unzip the installer file.|
+|===
+
+[NOTE]
+The space requirements listed in the previous table are based on average use. For environments with heavy traffic, validate the amount of space needed with your Customer Success Manager.
+
+=== System State Directory Device
+
+The main purpose of the system state directory device is to store system configuration and metadata, for example, database and packages. As package sizes can be arbitrarily large, it is important to estimate the minimum size requirements and allocate enough space for the dedicated device.
+
+Format this device either as `xfs` or `ext4` and mounted as `/var/lib/gravity`.  
+
+The following shell snippet is provided as an example for mounting the system state directory device using systemd mount files and cannot be used as-is in production. You can also mount the system state directory device by using `/etc/fstab` or some other method. Consult with your system administrator to determine the best way to meet this requirement. If you use the following example to guide this process, make sure to specify the correct device name in two places.
+
+----
+sudo mkfs.ext4 /dev/<device name>
+sudo mkdir -p /var/lib/gravity
+echo -e "[Mount]\nWhat=/dev/<device name>\nWhere=/var/lib/gravity\nType=ext4\n[Install]\nWantedBy=local-fs.target" | sudo tee /etc/systemd/system/var-lib-gravity.mount
+sudo systemctl daemon-reload
+sudo systemctl enable var-lib-gravity.mount
+sudo systemctl start var-lib-gravity.mount
+----
+
+=== Application Data Device
+
+The main purpose of the application data directory device is to store application configuration and data. The minimum amount of space required is 250GB, but your use case might require more. It is important to allocate enough space for the dedicated device.
+
+Format this device either as `xfs` or `ext4` and mounted as `/var/lib/data`. 
+
+The following shell snippet is provided as an example for mounting the application data device using systemd mount files, and cannot be used as-is in production. You can also mount the application data device using `/etc/fstab` or some other method. Consult with your system administrator to determine the best way to meet this requirement. If you use the following example to guide this process, make sure to specify the correct device name in two places.
+
+----
+sudo mkfs.ext4 /dev/<device name>
+sudo mkdir -p /var/lib/data
+echo -e "[Mount]\nWhat=/dev/<device name>\nWhere=/var/lib/data\nType=ext4\n[Install]\nWantedBy=local-fs.target" | sudo tee /etc/systemd/system/var-lib-data.mount
+sudo systemctl daemon-reload
+sudo systemctl enable var-lib-data.mount
+sudo systemctl start var-lib-data.mount
+----
+
+=== Etcd Device
+
+The main purpose of the etcd device is to provide dedicated storage for a distributed database used for cluster coordination. It does not require much space, 20GB is adequate.
+
+Format this device either as `xfs` or `ext4` and mounted as `/var/lib/gravity/planet/etcd`. 
+
+The following shell snippet mounts the etcd device using systemd mount files to the path `/var/lib/gravity/planet/etcd`.
+
+You can also mount the etcd device using `/etc/fstab` or another method. Consult with your system administrator to 
+determine the best way to meet this requirement. If you use the following example as a guide for this process, 
+specify the correct device name in two places.	
+
+[NOTE]	
+Mount this device AFTER you mount the System State device under `/var/lib/gravity/planet`. If you are using systemd units to mount the volumes, declare mount dependencies using `After=<device-name>.<mount>`.
+
+----
+sudo mkfs.ext4 /dev/<device name>
+sudo mkdir -p /var/lib/gravity/planet/etcd
+echo -e "[Mount]\nWhat=/dev/<device name>\nWhere=/var/lib/gravity/planet/etcd\nType=ext4\n[Install]\nWantedBy=local-fs.target" | sudo tee /etc/systemd/system/var-lib-gravity-planet-etcd.mount
+sudo systemctl daemon-reload
+sudo systemctl enable var-lib-gravity-planet-etcd.mount
+sudo systemctl start var-lib-gravity-planet-etcd.mount
+----
+
+=== Docker Device
+
+Unless specified, Docker configuration defaults to the use of the overlay driver, which is recommended for production.
+
+Format this device as `xfs` or `ext4` and mounted as `/var/lib/gravity/planet/docker`.
+
+The following example shell snippet mounts the Docker device using systemd mount files to the path:
+`/var/lib/gravity/planet/docker`. You can also mount the Docker device using `/etc/fstab` or another method.
+Consult with your system administrator to determine the best way to meet this requirement.
+If you use the following example as a guide for this process, specify the correct device name in two places.
+
+[NOTE]
+Mount this device AFTER you mount the System State device under `/var/lib/gravity/planet`. If you are using system.d units to mount the volumes, declare mount dependencies using `After=<device-name>.<mount>`
+
+----
+sudo mkfs.ext4 /dev/<device name>
+sudo mkdir -p /var/lib/gravity/planet/docker
+echo -e "[Mount]\nWhat=/dev/<device name>\nWhere=/var/lib/gravity/planet/docker\nType=ext4\n[Install]\nWantedBy=local-fs.target" | sudo tee /etc/systemd/system/var-lib-gravity-planet-docker.mount
+sudo systemctl daemon-reload	
+sudo systemctl enable var-lib-gravity-planet-docker.mount
+sudo systemctl start var-lib-gravity-planet-docker.mount
+----
+
+
+
+
+
 
 == Verify Devices
 

--- a/modules/ROOT/pages/prereq-hardware.adoc
+++ b/modules/ROOT/pages/prereq-hardware.adoc
@@ -9,8 +9,6 @@ To ensure the performance and stability of Anypoint Platform Private Cloud Editi
 [IMPORTANT]
 Before you install Anypoint Platform PCE, your infrastructure team must review each of the following sections and verify that your environment meets the stated disk and device requirements. If needed, contact your MuleSoft representative for assistance.
 
-(TBD: Reword properly, or update the whole content to better include Mon Center)  
-
 There are 2 components of PCE:  
 
 - Anypoint Platform Core
@@ -112,12 +110,12 @@ sudo systemctl start var-lib-gravity-planet-etcd.mount
 
 Unless specified, Docker configuration defaults to the use of the overlay driver, which is recommended for production.
 
-Format this device as `xfs` or `ext4` and mounted as `/var/lib/gravity/planet/docker`.
+Format this device as `xfs` or `ext4` and mount as `/var/lib/gravity/planet/docker`.
 
-The following example shell snippet mounts the Docker device using systemd mount files to the path:
+The following example shell snippet mounts the Docker device using `systemd` mount files to the path
 `/var/lib/gravity/planet/docker`. You can also mount the Docker device using `/etc/fstab` or another method.
 Consult with your system administrator to determine the best way to meet this requirement.
-If you use the following example as a guide for this process, specify the correct device name in two places.
+If you use the following example as a guide for this process, replace `<device name>` with the correct device name in two places.
 
 [NOTE]
 Mount this device AFTER you mount the System State device under `/var/lib/gravity/planet`. If you are using system.d units to mount the volumes, declare mount dependencies using `After=<device-name>.<mount>`
@@ -134,17 +132,17 @@ sudo systemctl start var-lib-gravity-planet-docker.mount
 
 == Monitoring Center Add-On
 
-Prerequisites the extra 3-nodes for the Monitoring Center Add-On.
+Prerequisites: The extra 3 nodes for the Monitoring Center Add-On.
 
 === Memory and CPU Requirements
 
-(TDB: At the moment, the only difference between the Monitoring Center and the Platform Core nodes are:  
+(TO-DO: As of 2020 Oct 1, the only differences between the Monitoring Center and the Platform Core nodes are:  
 
 - Memory
 - CPU
 - No etcd disk
 
-The disks most probably need to be different but needs to be confirmed.)
+The disks probably need to be different but this still needs to be confirmed before the PCE 3.0 release.)
 
 [%header%autowidth.spread]
 .Memory and CPU Requirements
@@ -163,9 +161,9 @@ For production environments, each node in your configuration must have the follo
 .Dedicated Device Requirements
 |===
 | Component |Size|Minimum IOPS|Mount Point|Description
-|HDD 2 xref:prereq-hardware#system-state-directory-device[System State Directory Device] | 200 GB |1500|/var/lib/gravity | Stores system configuration and metadata, including databases and packages. Because package sizes can be large, it is important to estimate the minimum size requirements and allocate enough space as a dedicated device before installation.
+|HDD 2 xref:prereq-hardware#system-state-directory-device[System State Directory Device] | 200 GB |1500|/var/lib/gravity | Stores system configuration and metadata, including databases and packages. Package sizes can be large, so it is important to estimate the minimum size requirements and allocate enough space as a dedicated device before installation.
 |HDD 3 xref:prereq-hardware#application-data-device[Application Data Device]| 250 GB |1500|/var/lib/data | Stores application configuration and data. The amount of space required should be at least 250 GB, but can vary depending on your specific use case. It is important to estimate the minimum size requirements and allocate enough space as a dedicated device ahead of time.
-|HDD 4 xref:prereq-hardware#docker-device[Docker Device] | 100 GB |3000|/var/lib/gravity/planet/docker | Used by Docker’s overlay storage driver. A minimum of 100GB is required for the overlay directory. Devices with 50GB or less will experience degraded system performance or might not work at all.
+|HDD 4 xref:prereq-hardware#docker-device[Docker Device] | 100 GB |3000|/var/lib/gravity/planet/docker | Used by Docker's overlay storage driver. A minimum of 100GB is required for the overlay directory. Devices with 50GB or less will experience degraded system performance or might not work at all.
 |/tmp (Installer) | 20 GB |N/A| |
 |/ (root) | 10 GB | N/A | | You must have at least 10GB in your home directory to download and unzip the installer file.|
 |===
@@ -177,9 +175,9 @@ The space requirements listed in the previous table are based on average use. Fo
 
 The main purpose of the system state directory device is to store system configuration and metadata, for example, database and packages. As package sizes can be arbitrarily large, it is important to estimate the minimum size requirements and allocate enough space for the dedicated device.
 
-Format this device either as `xfs` or `ext4` and mounted as `/var/lib/gravity`.  
+Format this device either as `xfs` or `ext4` and mount as `/var/lib/gravity`.  
 
-The following shell snippet is provided as an example for mounting the system state directory device using systemd mount files and cannot be used as-is in production. You can also mount the system state directory device by using `/etc/fstab` or some other method. Consult with your system administrator to determine the best way to meet this requirement. If you use the following example to guide this process, make sure to specify the correct device name in two places.
+The following shell snippet is provided as an example for mounting the system state directory device using `systemd` mount files and cannot be used as-is in production. You can also mount the system state directory device by using `/etc/fstab` or some other method. Consult with your system administrator to determine the best way to meet this requirement. If you use the following example as a guide for this process, replace `<device name>` with the correct device name in two places.
 
 ----
 sudo mkfs.ext4 /dev/<device name>
@@ -194,9 +192,9 @@ sudo systemctl start var-lib-gravity.mount
 
 The main purpose of the application data directory device is to store application configuration and data. The minimum amount of space required is 250GB, but your use case might require more. It is important to allocate enough space for the dedicated device.
 
-Format this device either as `xfs` or `ext4` and mounted as `/var/lib/data`. 
+Format this device either as `xfs` or `ext4` and mount as `/var/lib/data`. 
 
-The following shell snippet is provided as an example for mounting the application data device using systemd mount files, and cannot be used as-is in production. You can also mount the application data device using `/etc/fstab` or some other method. Consult with your system administrator to determine the best way to meet this requirement. If you use the following example to guide this process, make sure to specify the correct device name in two places.
+The following shell snippet is provided as an example for mounting the application data device using `systemd` mount files, and cannot be used as-is in production. You can also mount the application data device using `/etc/fstab` or some other method. Consult with your system administrator to determine the best way to meet this requirement. If you use the following example as a guide for this process, replace `<device name>` with the correct device name in two places.
 
 ----
 sudo mkfs.ext4 /dev/<device name>
@@ -211,12 +209,12 @@ sudo systemctl start var-lib-data.mount
 
 Unless specified, Docker configuration defaults to the use of the overlay driver, which is recommended for production.
 
-Format this device as `xfs` or `ext4` and mounted as `/var/lib/gravity/planet/docker`.
+Format this device as `xfs` or `ext4` and mount as `/var/lib/gravity/planet/docker`.
 
-The following example shell snippet mounts the Docker device using systemd mount files to the path:
+The following example shell snippet mounts the Docker device using `systemd` mount files to the path:
 `/var/lib/gravity/planet/docker`. You can also mount the Docker device using `/etc/fstab` or another method.
 Consult with your system administrator to determine the best way to meet this requirement.
-If you use the following example as a guide for this process, specify the correct device name in two places.
+If you use the following example as a guide for this process, replace `<device name>` with the correct device name in two places.
 
 [NOTE]
 Mount this device AFTER you mount the System State device under `/var/lib/gravity/planet`. If you are using system.d units to mount the volumes, declare mount dependencies using `After=<device-name>.<mount>`

--- a/modules/ROOT/pages/prereq-hardware.adoc
+++ b/modules/ROOT/pages/prereq-hardware.adoc
@@ -17,6 +17,9 @@ There are 2 components of PCE:
 - Monitoring Center Add-On
 
 == Anypoint Platform Core
+
+Prerequisites for 4-nodes or 7-nodes to run the Anypoint Platform Core.
+
 === Memory and CPU Requirements
 
 [%header%autowidth.spread]
@@ -130,6 +133,9 @@ sudo systemctl start var-lib-gravity-planet-docker.mount
 
 
 == Monitoring Center Add-On
+
+Prerequisites the extra 3-nodes for the Monitoring Center Add-On.
+
 === Memory and CPU Requirements
 
 (TDB: At the moment, the only difference between the Monitoring Center and the Platform Core nodes are Memory and CPU.  

--- a/modules/ROOT/pages/prereq-hardware.adoc
+++ b/modules/ROOT/pages/prereq-hardware.adoc
@@ -138,7 +138,12 @@ Prerequisites the extra 3-nodes for the Monitoring Center Add-On.
 
 === Memory and CPU Requirements
 
-(TDB: At the moment, the only difference between the Monitoring Center and the Platform Core nodes are Memory and CPU.  
+(TDB: At the moment, the only difference between the Monitoring Center and the Platform Core nodes are:  
+
+- Memory
+- CPU
+- No etcd disk
+
 The disks most probably need to be different but needs to be confirmed.)
 
 [%header%autowidth.spread]
@@ -161,7 +166,6 @@ For production environments, each node in your configuration must have the follo
 |HDD 2 xref:prereq-hardware#system-state-directory-device[System State Directory Device] | 200 GB |1500|/var/lib/gravity | Stores system configuration and metadata, including databases and packages. Because package sizes can be large, it is important to estimate the minimum size requirements and allocate enough space as a dedicated device before installation.
 |HDD 3 xref:prereq-hardware#application-data-device[Application Data Device]| 250 GB |1500|/var/lib/data | Stores application configuration and data. The amount of space required should be at least 250 GB, but can vary depending on your specific use case. It is important to estimate the minimum size requirements and allocate enough space as a dedicated device ahead of time.
 |HDD 4 xref:prereq-hardware#docker-device[Docker Device] | 100 GB |3000|/var/lib/gravity/planet/docker | Used by Docker’s overlay storage driver. A minimum of 100GB is required for the overlay directory. Devices with 50GB or less will experience degraded system performance or might not work at all.
-|HDD 5 xref:prereq-hardware#etcd-device[Etcd Device] | 20 GB |3000|/var/lib/gravity/planet/etcd | Provides dedicated storage for the distributed database used for cluster coordination.
 |/tmp (Installer) | 20 GB |N/A| |
 |/ (root) | 10 GB | N/A | | You must have at least 10GB in your home directory to download and unzip the installer file.|
 |===
@@ -201,30 +205,6 @@ echo -e "[Mount]\nWhat=/dev/<device name>\nWhere=/var/lib/data\nType=ext4\n[Inst
 sudo systemctl daemon-reload
 sudo systemctl enable var-lib-data.mount
 sudo systemctl start var-lib-data.mount
-----
-
-=== Etcd Device
-
-The main purpose of the etcd device is to provide dedicated storage for a distributed database used for cluster coordination. It does not require much space, 20GB is adequate.
-
-Format this device either as `xfs` or `ext4` and mounted as `/var/lib/gravity/planet/etcd`. 
-
-The following shell snippet mounts the etcd device using systemd mount files to the path `/var/lib/gravity/planet/etcd`.
-
-You can also mount the etcd device using `/etc/fstab` or another method. Consult with your system administrator to 
-determine the best way to meet this requirement. If you use the following example as a guide for this process, 
-specify the correct device name in two places.	
-
-[NOTE]	
-Mount this device AFTER you mount the System State device under `/var/lib/gravity/planet`. If you are using systemd units to mount the volumes, declare mount dependencies using `After=<device-name>.<mount>`.
-
-----
-sudo mkfs.ext4 /dev/<device name>
-sudo mkdir -p /var/lib/gravity/planet/etcd
-echo -e "[Mount]\nWhat=/dev/<device name>\nWhere=/var/lib/gravity/planet/etcd\nType=ext4\n[Install]\nWantedBy=local-fs.target" | sudo tee /etc/systemd/system/var-lib-gravity-planet-etcd.mount
-sudo systemctl daemon-reload
-sudo systemctl enable var-lib-gravity-planet-etcd.mount
-sudo systemctl start var-lib-gravity-planet-etcd.mount
 ----
 
 === Docker Device

--- a/modules/ROOT/pages/prereq-hardware.adoc
+++ b/modules/ROOT/pages/prereq-hardware.adoc
@@ -9,8 +9,10 @@ To ensure the performance and stability of Anypoint Platform Private Cloud Editi
 [IMPORTANT]
 Before you install Anypoint Platform PCE, your infrastructure team must review each of the following sections and verify that your environment meets the stated disk and device requirements. If needed, contact your MuleSoft representative for assistance.
 
-(TBD: Reword properly, or update the whole content to better include Mon Center)
-There are 2 components of PCE:
+(TBD: Reword properly, or update the whole content to better include Mon Center)  
+
+There are 2 components of PCE:  
+
 - Anypoint Platform Core
 - Monitoring Center Add-On
 
@@ -130,10 +132,8 @@ sudo systemctl start var-lib-gravity-planet-docker.mount
 == Monitoring Center Add-On
 === Memory and CPU Requirements
 
-(
-TDB: At the moment, the only difference between the Monitoring Center and the Platform Core nodes are Memory and CPU.
-The disks most probably need to be different but needs to be confirmed.
-)
+(TDB: At the moment, the only difference between the Monitoring Center and the Platform Core nodes are Memory and CPU.  
+The disks most probably need to be different but needs to be confirmed.)
 
 [%header%autowidth.spread]
 .Memory and CPU Requirements
@@ -243,11 +243,6 @@ sudo systemctl daemon-reload
 sudo systemctl enable var-lib-gravity-planet-docker.mount
 sudo systemctl start var-lib-gravity-planet-docker.mount
 ----
-
-
-
-
-
 
 == Verify Devices
 

--- a/modules/ROOT/pages/prereq-software.adoc
+++ b/modules/ROOT/pages/prereq-software.adoc
@@ -18,8 +18,8 @@ Before you install Anypoint Platform PCE, your infrastructure team must review e
 === Verify Linux Distribution
 The following Linux distributions are supported:
 
-* Red Hat Enterprise Linux (RHEL) 7.5.x, 7.6, 7.7, 7.8, and 8.1
-* CentOS 7.5.x, 7.6, 7.7, 7.8, and 8.1
+* Red Hat Enterprise Linux (RHEL) 7.5.x, 7.6, 7.7, 7.8 ~~, and 8.1~~ (8.x coming soon because of SELinux compatibility)
+* CentOS 7.5.x, 7.6, 7.7, 7.8 ~~, and 8.1~~ (8.x coming soon because of SELinux compatibility)
 
 === Check for SELinux Custom Profiles
 Although SELinux is not required, Anypoint Platform PCE supports the default SELinux profile running 
@@ -79,16 +79,6 @@ echo net.ipv4.ip_forward=1 >> /etc/sysctl.d/10-ipv4-forwarding.conf
 Ensure that no processes or files conflict with those settings.
 
 == Third Party Software Prerequisites
-
-=== Install LVM2
-
-To install and run Anypoint Platform PCE, you must install and use Logical Volume Manager 2 (LVM2). LVM2 is a tool that adds a layer of abstraction between your operating system and the disks and partitions it uses. You must have root access to install LVM2.
-
-You can install LVM2 using Yum. Yum is an open-source command-line package-management utility for Linux operating systems using the RPM Package Manager. Using Yum, you can install LVM2 using the following command:
-
-----
-sudo yum install lvm2
-----
 
 === Requirements When Firewalld Is Enabled
 

--- a/modules/ROOT/pages/prereq-software.adoc
+++ b/modules/ROOT/pages/prereq-software.adoc
@@ -18,8 +18,8 @@ Before you install Anypoint Platform PCE, your infrastructure team must review e
 === Verify Linux Distribution
 The following Linux distributions are supported:
 
-* Red Hat Enterprise Linux (RHEL) 7.5.x, 7.6, 7.7, 7.8 ~~, and 8.1~~ (8.x coming soon because of SELinux compatibility)
-* CentOS 7.5.x, 7.6, 7.7, 7.8 ~~, and 8.1~~ (8.x coming soon because of SELinux compatibility)
+* Red Hat Enterprise Linux (RHEL) 7.5.x, 7.6, 7.7, 7.8 (TO-DO: 8.1 support not present currently due to SELinux compatibility but will be included in PCE 3.0)
+* CentOS 7.5.x, 7.6, 7.7, 7.8 (TO-DO: 8.1 support not present currently due to SELinux compatibility but will be included in PCE 3.0)
 
 === Check for SELinux Custom Profiles
 Although SELinux is not required, Anypoint Platform PCE supports the default SELinux profile running 

--- a/modules/ROOT/pages/supported-cluster-config.adoc
+++ b/modules/ROOT/pages/supported-cluster-config.adoc
@@ -8,8 +8,6 @@ To ensure platform performance, stability, and high availability, Anypoint Platf
 
 To ensure high availability and performance, each node must run on its own server in both configurations. If you are using a virtual machine to host the nodes, you must ensure that each VM node is running on a separate physical server.
 
-(TBD: Reword properly, or update the whole content to better include Mon Center)
-
 There are 2 components of PCE:
 
 - Anypoint Platform Core
@@ -22,11 +20,11 @@ There are 2 components of PCE:
 
 Three is the minimum number of nodes that can enable high-availability and failover. In this configuration, each node hosts the platform applications and services. You must configure a load balancer to use round-robin distribution of traffic among each of the four nodes.
 
-(TBD: Below diagram is outdated. It should include another node that doesn't run Database and Object Store, just services.)
+(TO-DO: Below diagram will be updated before PCE 3.0 release to include another node that doesn't run Database and Object Store, just services.)
 
 image::prereqs-priv-cloud-3-node.png[3-node Configuration]
 
-Three of the nodes host an instance of the database and object store. Hosting the database and object store enables persistence but requires larger minimum disk and memory requirements. Although three of the nodes contain a database, only one  database is used as the master. Applications on each node write to this database only. The other two database instances are hot standby instances of the master database that take over as the master database in case of failure.
+Three of the nodes host an instance of the database and object store. Hosting the database and object store enables persistence but requires larger minimum disk and memory requirements. Although three of the nodes contain a database, only one database is used as the master. Applications on each node write to this database only. The other two database instances are hot standby instances of the master database that take over as the master database in case of failure.
 
 ==== Environment Limitations
 
@@ -34,7 +32,7 @@ You must understand and adhere to the following recommendations and limitations 
 
 These limitations are based on a 4-node environment consisting of 4 nodes of 8 cores and 32GB RAM.
 
-(TBD: Below limits will be updated as a result of performance testing)
+(TO-DO: Below limits will be updated before PCE 3.0 release to reflect performance testing.)
 
 **** Runtime management
 
@@ -75,7 +73,7 @@ These limitations are based on a 4-node environment consisting of 4 nodes of 8 c
 
 In the 7-node configuration, four nodes are dedicated to hosting platform applications and services. The other three nodes host the database and object store instances. Although each node contains a database, only one of the database nodes is used as the master. Applications on each node write to this database only. The other two database instances are hot standby instances of the master database that take over as the master database in case of failure.
 
-(TBD: Below diagram is outdated. It should include another node that runs just services.)
+(TO-DO: Below diagram will be updated before PCE 3.0 release to include another node that runs just services.)
 
 image::prereqs-priv-cloud-6-node.png[6-node Configuration]
 
@@ -87,7 +85,7 @@ You must understand and adhere to the following recommendations and limitations 
 
 These limitations are based on a 7-node environment consisting of 7 nodes of 8 cores and 32GB RAM.
 
-(TBD: Below limits will be updated as a result of performance testing)
+(TO-DO: Below limits will be updated before PCE 3.0 release to reflect performance testing.)
 
 **** Runtime management
 
@@ -130,7 +128,8 @@ in which:
 
 === 3-Node Configuration
 
-(TBD, but first try...)
-Monitoring Center can be enabled as an additional add-on.  
-Monitoring Center runs on 3 nodes that are different from the ones to run the Anypoint Platform Core.
+Monitoring Center can be enabled as an additional add-on.
+
+Monitoring Center runs on 3 nodes separate from the nodes that run the Anypoint Platform Core.
+
 These nodes host the stateful and stateless services that compose Monitoring Center.

--- a/modules/ROOT/pages/supported-cluster-config.adoc
+++ b/modules/ROOT/pages/supported-cluster-config.adoc
@@ -4,23 +4,27 @@ include::_attributes.adoc[]
 endif::[]
 :page-aliases: prereq-env.adoc
 
-To ensure platform performance, stability, and high availability, Anypoint Platform Private Cloud Edition (Anypoint Platform PCE) supports two network configurations: 3-node and 6-node.
+To ensure platform performance, stability, and high availability, Anypoint Platform Private Cloud Edition (Anypoint Platform PCE) supports two network configurations: 4-node and 7-node.
 
 To ensure high availability and performance, each node must run on its own server in both configurations. If you are using a virtual machine to host the nodes, you must ensure that each VM node is running on a separate physical server.
 
-== 3-Node Configuration
+== 4-Node Configuration
 
-Three is the minimum number of nodes that can enable high-availability and failover. In this configuration, each node hosts the platform applications and services. You must configure a load balancer to use round-robin distribution of traffic among each of the three nodes.
+Three is the minimum number of nodes that can enable high-availability and failover. In this configuration, each node hosts the platform applications and services. You must configure a load balancer to use round-robin distribution of traffic among each of the four nodes.
+
+(TBD: Below diagram is outdated. It should include another node that doesn't run Database and Object Store, just services.)
 
 image::prereqs-priv-cloud-3-node.png[3-node Configuration]
 
-Each node also hosts an instance of the database and object store. Hosting the database and object store enables persistence but requires larger minimum disk and memory requirements. Although each node contains a database, only one  database is used as the master. Applications on each node write to this database only. The other two database instances are hot standby instances of the master database that take over as the master database in case of failure.
+Three of the nodes host an instance of the database and object store. Hosting the database and object store enables persistence but requires larger minimum disk and memory requirements. Although three of the nodes contain a database, only one  database is used as the master. Applications on each node write to this database only. The other two database instances are hot standby instances of the master database that take over as the master database in case of failure.
 
 === Environment Limitations
 
 You must understand and adhere to the following recommendations and limitations when installing Anypoint Platform PCE and deploying apps.
 
-These limitations are based on a 3-node environment consisting of 3 nodes of 8 cores and 32GB RAM.
+These limitations are based on a 4-node environment consisting of 4 nodes of 8 cores and 32GB RAM.
+
+(TBD: Below limits will be updated as a result of performance testing)
 
 **** Runtime management
 
@@ -57,9 +61,11 @@ These limitations are based on a 3-node environment consisting of 3 nodes of 8 c
 
 ***** Maximum of 30,000 Exchange assets
 
-== 6-Node Configuration
+== 7-Node Configuration
 
-In the 6-node configuration, three nodes are dedicated to hosting platform applications and services. The other three nodes host the database and object store instances. Although each node contains a database, only one of the database nodes is used as the master. Applications on each node write to this database only. The other two database instances are hot standby instances of the master database that take over as the master database in case of failure.
+In the 7-node configuration, four nodes are dedicated to hosting platform applications and services. The other three nodes host the database and object store instances. Although each node contains a database, only one of the database nodes is used as the master. Applications on each node write to this database only. The other two database instances are hot standby instances of the master database that take over as the master database in case of failure.
+
+(TBD: Below diagram is outdated. It should include another node that runs just services.)
 
 image::prereqs-priv-cloud-6-node.png[6-node Configuration]
 
@@ -69,7 +75,9 @@ You must configure a load balancer to use round-robin distribution of traffic am
 
 You must understand and adhere to the following recommendations and limitations when installing Anypoint Platform PCE and deploying apps.
 
-These limitations are based on a 6-node environment consisting of 6 nodes of 8 cores and 32GB RAM.
+These limitations are based on a 7-node environment consisting of 7 nodes of 8 cores and 32GB RAM.
+
+(TBD: Below limits will be updated as a result of performance testing)
 
 **** Runtime management
 

--- a/modules/ROOT/pages/supported-cluster-config.adoc
+++ b/modules/ROOT/pages/supported-cluster-config.adoc
@@ -8,7 +8,17 @@ To ensure platform performance, stability, and high availability, Anypoint Platf
 
 To ensure high availability and performance, each node must run on its own server in both configurations. If you are using a virtual machine to host the nodes, you must ensure that each VM node is running on a separate physical server.
 
-== 4-Node Configuration
+(TBD: Reword properly, or update the whole content to better include Mon Center)
+
+There are 2 components of PCE:
+
+- Anypoint Platform Core
+
+- Monitoring Center Add-On
+
+== Anypoint Platform Core
+
+=== 4-Node Configuration
 
 Three is the minimum number of nodes that can enable high-availability and failover. In this configuration, each node hosts the platform applications and services. You must configure a load balancer to use round-robin distribution of traffic among each of the four nodes.
 
@@ -18,7 +28,7 @@ image::prereqs-priv-cloud-3-node.png[3-node Configuration]
 
 Three of the nodes host an instance of the database and object store. Hosting the database and object store enables persistence but requires larger minimum disk and memory requirements. Although three of the nodes contain a database, only one  database is used as the master. Applications on each node write to this database only. The other two database instances are hot standby instances of the master database that take over as the master database in case of failure.
 
-=== Environment Limitations
+==== Environment Limitations
 
 You must understand and adhere to the following recommendations and limitations when installing Anypoint Platform PCE and deploying apps.
 
@@ -61,7 +71,7 @@ These limitations are based on a 4-node environment consisting of 4 nodes of 8 c
 
 ***** Maximum of 30,000 Exchange assets
 
-== 7-Node Configuration
+=== 7-Node Configuration
 
 In the 7-node configuration, four nodes are dedicated to hosting platform applications and services. The other three nodes host the database and object store instances. Although each node contains a database, only one of the database nodes is used as the master. Applications on each node write to this database only. The other two database instances are hot standby instances of the master database that take over as the master database in case of failure.
 
@@ -71,7 +81,7 @@ image::prereqs-priv-cloud-6-node.png[6-node Configuration]
 
 You must configure a load balancer to use round-robin distribution of traffic among all of the nodes in your cluster.
 
-=== Environment Limitations
+==== Environment Limitations
 
 You must understand and adhere to the following recommendations and limitations when installing Anypoint Platform PCE and deploying apps.
 
@@ -114,3 +124,13 @@ in which:
 **** Exchange
 
 ***** Maximum 60,000 Exchange Assets
+
+
+== Monitoring Center Add-On
+
+=== 3-Node Configuration
+
+(TBD, but first try...)
+Monitoring Center can be enabled as an additional add-on.  
+Monitoring Center runs on 3 nodes that are different from the ones to run the Anypoint Platform Core.
+These nodes host the stateful and stateless services that compose Monitoring Center.


### PR DESCRIPTION
The changes included in the PR are very raw.
The field starts their validation on the installation and needs to have the information, even when it's not in perfect shape (or very far from perfect).
The field needs to start working on this on 10/05/20 so even in this shape this will allow them to make progress and iterate through the docs.
We can make a disclaimer that the docs are under work to set the expectations on the quality.

Main changes:
- 3 nodes is not 4 nodes. 6 nodes is now 7 nodes. The new node is in both cases for platform apps and services, not databases.
- Monitoring Center can be enabled as an add-on. In order to differentiate this new part I introduced the terms `Anypoint Platform Core` and `Monitoring Center Add-On` which by no means are final. Just filling the gap to differentiate these 2.
There has to be a rework or reorg to better include this new concept in a more natural way.
- `Anypoint Platform Core` and `Monitoring Center Add-On` hardware requirements are slightly different. And might be more different after performance tests.
- Monitoring Center requires a new ingress port (`8895` | `30895`).

Other changes:
- `Anypoint Studio` since `7.7`
- AWS provisioner version updated to `3.0.6`
- `/var/lib/gravity` disk size increased to `200 GB`
- RHEL 8.x not supported yet
