### PR TITLE
[AOP-3174] Update RHEL versions for PCE 2.1

### DIFF
--- a/modules/ROOT/pages/prereq-software.adoc
+++ b/modules/ROOT/pages/prereq-software.adoc
@@ -18,8 +18,8 @@ Before you install Anypoint Platform PCE, your infrastructure team must review e
 === Verify Linux Distribution
 The following Linux distributions are supported:
 
-* Red Hat Enterprise Linux (RHEL) 7.5.x, 7.6, 7.7, 7.8, and 8.1
-* CentOS 7.5.x, 7.6, 7.7, 7.8, and 8.1
+* Red Hat Enterprise Linux (RHEL) 7.8, and 8.1
+* CentOS 7.8, and 8.1
 
 === Check for SELinux Custom Profiles
 Although SELinux is not required, Anypoint Platform PCE supports the default SELinux profile running 

--- a/modules/ROOT/pages/prereq-software.adoc
+++ b/modules/ROOT/pages/prereq-software.adoc
@@ -18,8 +18,8 @@ Before you install Anypoint Platform PCE, your infrastructure team must review e
 === Verify Linux Distribution
 The following Linux distributions are supported:
 
-* Red Hat Enterprise Linux (RHEL) 7.8, and 8.1
-* CentOS 7.8, and 8.1
+* Red Hat Enterprise Linux (RHEL) 7.8 and 8.1
+* CentOS 7.8 and 8.1
 
 === Check for SELinux Custom Profiles
 Although SELinux is not required, Anypoint Platform PCE supports the default SELinux profile running 


### PR DESCRIPTION
[AOP-3174] Update RHEL versions for PCE 2.1 as the older RHEL versions are not recommended any more