### PR TITLE
DOCS-10127 Update backup-and-disaster-recovery.adoc

### DIFF
--- a/modules/ROOT/pages/backup-and-disaster-recovery.adoc
+++ b/modules/ROOT/pages/backup-and-disaster-recovery.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-To preserve your data in case of system failure or problems with other operations, such as patching or performing upgrades, ensure that your system is automatically backed up. Regular backups are extremely important for disaster recovery procedures. Configure your backup to run at least once per day; hourly is recommended. Store your backup archive on external storage outside the Anypoint Platform cluster.
+To preserve your data in case of system failure or problems with other operations, such as patching or performing upgrades, ensure that your system is automatically backed up. Regular backups are extremely important for disaster recovery procedures. Configure your backup to run at least once per day; or more often depending on your requirements. Store your backup archive on external storage outside the Anypoint Platform cluster.
 
 Anypoint Platform Private Cloud Edition (Anypoint Platform PCE) requires you to install, configure, and manage an NFS server. Ensure that you configure and perform frequent backups of this server.
 


### PR DESCRIPTION
Reword the backup-restore summary to remove the reference to `hourly` and mention something that's in the lines of "as often as your policies/requirements/needs dictate".