### PR TITLE
W-12097077: Documenting new 3.2 Kernel settings

### DIFF
--- a/modules/ROOT/pages/prereq-software.adoc
+++ b/modules/ROOT/pages/prereq-software.adoc
@@ -68,7 +68,7 @@ The following flags must be enabled:
 * `fs.may_detach_mounts=1`
 * `fs.inotify.max_user_watches=524288`
 
-Required settings for the kubelet, which does not update the Kernel settings automatically:
+The kubelet requires the following settings, which do not update the Kernel settings automatically:
 
 * `vm.overcommit_memory=1`
 * `kernel.panic=10`

--- a/modules/ROOT/pages/prereq-software.adoc
+++ b/modules/ROOT/pages/prereq-software.adoc
@@ -68,13 +68,13 @@ The following flags must be enabled:
 * `fs.may_detach_mounts=1`
 * `fs.inotify.max_user_watches=524288`
 
-Required settings for the Kubelet which does not update the Kernel settings automatically in PCE 3.2:
+Required settings for the kubelet, which does not update the Kernel settings automatically:
 
 * `vm.overcommit_memory=1`
 * `kernel.panic=10`
 * `kernel.panic_on_oops=1`
 
-Ensure that no processes on your system overrides any flag above. To set a parameter, use `sysctl -w`, as shown in the following example:
+Ensure that no processes on your system overrides any of these flags. To set a parameter, use `sysctl -w`, as shown in the following example:
 
 ----
 root$ sysctl -w net.ipv4.ip_forward=1
@@ -85,7 +85,8 @@ To make the changes permanent for the next reboot, write the changes to a file u
 ----
 echo net.ipv4.ip_forward=1 >> /etc/sysctl.d/10-ipv4-forwarding.conf
 ----
-Permanently configure settings required by the Kubelet:
+
+Permanently configure settings required by the kubelet:
 ----
 cat > /etc/sysctl.d/90-kubelet.conf << EOF
 vm.overcommit_memory=1

--- a/modules/ROOT/pages/prereq-software.adoc
+++ b/modules/ROOT/pages/prereq-software.adoc
@@ -68,7 +68,13 @@ The following flags must be enabled:
 * `fs.may_detach_mounts=1`
 * `fs.inotify.max_user_watches=524288`
 
-Ensure that no processes on your system set this flag to `false`. To set a parameter, use `sysctl -w`, as shown in the following example:
+Required settings for the Kubelet which does not update the Kernel settings automatically in PCE 3.2:
+
+* `vm.overcommit_memory=1`
+* `kernel.panic=10`
+* `kernel.panic_on_oops=1`
+
+Ensure that no processes on your system overrides any flag above. To set a parameter, use `sysctl -w`, as shown in the following example:
 
 ----
 root$ sysctl -w net.ipv4.ip_forward=1
@@ -78,6 +84,14 @@ To make the changes permanent for the next reboot, write the changes to a file u
 
 ----
 echo net.ipv4.ip_forward=1 >> /etc/sysctl.d/10-ipv4-forwarding.conf
+----
+Permanently configure settings required by the Kubelet:
+----
+cat > /etc/sysctl.d/90-kubelet.conf << EOF
+vm.overcommit_memory=1
+kernel.panic=10
+kernel.panic_on_oops=1
+EOF
 ----
 
 Ensure that no processes or files conflict with those settings.


### PR DESCRIPTION
In PCE 3.2, the Kubelet now runs with protectKernelDefault set to true which means some Kernel settings will no longer be adjusted automatically. Instead these Kernel settings must be configured by the system administrator, either manually or via a script within the /etc/sysctl.d directory.

Related tickets and Slack thread:
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001E1K2pYAF/view
https://salesforce-internal.slack.com/archives/C0160CZN2RG/p1669048921514469
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000010kZacYAE/view