### PR TITLE
Update healthcheck port from 10248 to 10256

### DIFF
--- a/modules/ROOT/pages/prereq-hardware.adoc
+++ b/modules/ROOT/pages/prereq-hardware.adoc
@@ -369,7 +369,7 @@ Your load balancer must route the following TCP ports:
 
 In each case, your load balancer must listen on the load balancer port and redirect incoming requests to the instance port. Your Anypoint Platform PCE installation includes an internal NGINX server that listens on each of the configured instance ports, and then performs the action listed in the Internal Usage column.
 
-Your load balancer should poll the address `HTTP:10248/healthz` to run a health check on your platform servers and confirm that they are accessible.
+Your load balancer should poll the address `HTTP:10256/healthz` to run a health check on your platform servers and confirm that they are accessible.
 
 [NOTE]
 Do not configure SSL certificates in your load balancer. TLS termination is handled by the platform with the certificates configured using Access Management. See xref:config-workflow.adoc[Configure Anypoint Platform PCE].


### PR DESCRIPTION
With changes to gravity/kubernetes in version 3.x, port 10248 is now only internally accessible and cannot be used for Load Balancer health/liveness checks. I suggest changing to the kube-proxy 10256 port that still has an externally accessible /healthz endpoint that provides an HTTP:200 response and json date/timestamp.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released