### PR TITLE
W-16950393 Fix review max title lentgh

### DIFF
--- a/modules/ROOT/pages/supported-cluster-config.adoc
+++ b/modules/ROOT/pages/supported-cluster-config.adoc
@@ -105,7 +105,7 @@ See the Access Management documentation for more information on xref:access-mana
 | Maximum number of custom configurations per organization | 500 | 500
 | Maximum number of pages in a portal | 50 | 50
 | Maximum length of page name | 128 characters | 128 characters
-| Maximum review title length | 300 characters | 300 characters
+| Maximum review title length | 30 characters | 30 characters
 | Maximum review text length | 2048 characters | 2048 characters
 |===
 


### PR DESCRIPTION
Fix typo introduced in [this commit](https://github.com/mulesoft/docs-private-cloud/commit/292536e2a69c1e085b0e6a7ab152e5c21fe1dbe5): maximum review tittle length is 30, not 300

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released